### PR TITLE
improved server pinging and datagrid cell coloring

### DIFF
--- a/CS2ServerPicker/App.vb
+++ b/CS2ServerPicker/App.vb
@@ -121,7 +121,7 @@
             Environment.NewLine +
             "Author: FN-FAL113 (github username)" + Environment.NewLine +
             "License: GNU General Public License V3" + Environment.NewLine +
-            "App Version: 2.0.5",
+            "App Version: 2.0.6",
             "App Info"
         )
     End Sub

--- a/CS2ServerPicker/My Project/AssemblyInfo.vb
+++ b/CS2ServerPicker/My Project/AssemblyInfo.vb
@@ -32,6 +32,6 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")>
 
-<Assembly: AssemblyVersion("2.0.5.0")>
-<Assembly: AssemblyFileVersion("2.0.5.0")>
+<Assembly: AssemblyVersion("2.0.6.0")>
+<Assembly: AssemblyFileVersion("2.0.6.0")>
 <Assembly: NeutralResourcesLanguage("en")>

--- a/CS2ServerPicker/Services/DataGridViewService.vb
+++ b/CS2ServerPicker/Services/DataGridViewService.vb
@@ -1,21 +1,22 @@
 ﻿Module DataGridViewService
     Public Sub Load_Server_List()
-        Dim i As Integer = 0
+        Dim rowIndex As Integer = 0
 
         Dim serverDict As Dictionary(Of String, String) = IIf(App.Get_Is_Clustered(), App.Get_Server_Dictionary_Clustered(), App.Get_Server_Dictionary_Unclustered)
 
         ' display each server name key value from server dictionary in the datagridview control
         For Each kvp As KeyValuePair(Of String, String) In serverDict
             App.Get_DataGridView_Control().Rows().Add()
-            App.Get_DataGridView_Control().Rows(i).Cells(0).Value = kvp.Key
+            App.Get_DataGridView_Control().Rows(rowIndex).Cells(0).Value = kvp.Key
 
-            i += 1
+            rowIndex += 1
         Next
     End Sub
 
     Public Sub Clear_Column_Values()
         For Each row As DataGridViewRow In App.Get_DataGridView_Control().Rows
             row.Cells(1).Value = String.Empty
+            row.Cells(1).Style.BackColor = Color.Empty
         Next
     End Sub
 

--- a/CS2ServerPicker/Services/PingService.vb
+++ b/CS2ServerPicker/Services/PingService.vb
@@ -95,7 +95,7 @@
 
         If String.IsNullOrEmpty(serverName) Then
             For Each ping As Net.NetworkInformation.Ping In pingObjs.Values
-                pingObjs.Item(serverName).SendAsyncCancel()
+                ping.SendAsyncCancel()
                 ping.Dispose()
             Next
 


### PR DESCRIPTION
## Changes
- ping by server ping addresses instead of by first server address host range values. Get ping result on first successful ping instead.
- Cell coloring based on ping results (green = success, orange = timed out, red = blocked). 

## Issue
- Resolves #27 