### PR TITLE
Presets feature and chores

### DIFF
--- a/CS2ServerPicker/App.Designer.vb
+++ b/CS2ServerPicker/App.Designer.vb
@@ -32,9 +32,10 @@ Partial Class App
         Me.UnblockSelectedButton = New System.Windows.Forms.Button()
         Me.BlockAllButton = New System.Windows.Forms.Button()
         Me.InfoButton = New System.Windows.Forms.Button()
-        Me.PictureBox1 = New System.Windows.Forms.PictureBox()
         Me.ProgBar = New System.Windows.Forms.ProgressBar()
         Me.ClusterButton = New System.Windows.Forms.Button()
+        Me.PictureBox1 = New System.Windows.Forms.PictureBox()
+        Me.PresetsButton = New System.Windows.Forms.Button()
         CType(Me.MainDataGridView, System.ComponentModel.ISupportInitialize).BeginInit()
         CType(Me.PictureBox1, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
@@ -146,18 +147,6 @@ Partial Class App
         Me.InfoButton.Text = "Info"
         Me.InfoButton.UseVisualStyleBackColor = True
         '
-        'PictureBox1
-        '
-        Me.PictureBox1.BackColor = System.Drawing.Color.Transparent
-        Me.PictureBox1.BackgroundImage = Global.CS2ServerPicker.My.Resources.Resources.GitHub_Mark
-        Me.PictureBox1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
-        Me.PictureBox1.Cursor = System.Windows.Forms.Cursors.Hand
-        Me.PictureBox1.Location = New System.Drawing.Point(6, 4)
-        Me.PictureBox1.Name = "PictureBox1"
-        Me.PictureBox1.Size = New System.Drawing.Size(30, 28)
-        Me.PictureBox1.TabIndex = 5
-        Me.PictureBox1.TabStop = False
-        '
         'ProgBar
         '
         Me.ProgBar.Location = New System.Drawing.Point(300, 26)
@@ -178,11 +167,34 @@ Partial Class App
         Me.ClusterButton.Text = "Uncluster"
         Me.ClusterButton.UseVisualStyleBackColor = True
         '
+        'PictureBox1
+        '
+        Me.PictureBox1.BackColor = System.Drawing.Color.Transparent
+        Me.PictureBox1.BackgroundImage = Global.CS2ServerPicker.My.Resources.Resources.GitHub_Mark
+        Me.PictureBox1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch
+        Me.PictureBox1.Cursor = System.Windows.Forms.Cursors.Hand
+        Me.PictureBox1.Location = New System.Drawing.Point(6, 4)
+        Me.PictureBox1.Name = "PictureBox1"
+        Me.PictureBox1.Size = New System.Drawing.Size(30, 28)
+        Me.PictureBox1.TabIndex = 5
+        Me.PictureBox1.TabStop = False
+        '
+        'PresetsButton
+        '
+        Me.PresetsButton.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.PresetsButton.Location = New System.Drawing.Point(157, 25)
+        Me.PresetsButton.Name = "PresetsButton"
+        Me.PresetsButton.Size = New System.Drawing.Size(87, 24)
+        Me.PresetsButton.TabIndex = 8
+        Me.PresetsButton.Text = "Presets"
+        Me.PresetsButton.UseVisualStyleBackColor = True
+        '
         'App
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 15.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(756, 430)
+        Me.Controls.Add(Me.PresetsButton)
         Me.Controls.Add(Me.ClusterButton)
         Me.Controls.Add(Me.ProgBar)
         Me.Controls.Add(Me.PictureBox1)
@@ -215,4 +227,5 @@ Partial Class App
     Friend WithEvents PictureBox1 As PictureBox
     Friend WithEvents ProgBar As ProgressBar
     Friend WithEvents ClusterButton As Button
+    Friend WithEvents PresetsButton As Button
 End Class

--- a/CS2ServerPicker/App.vb
+++ b/CS2ServerPicker/App.vb
@@ -121,7 +121,7 @@
             Environment.NewLine +
             "Author: FN-FAL113 (github username)" + Environment.NewLine +
             "License: GNU General Public License V3" + Environment.NewLine +
-            "App Version: 2.0.6",
+            "App Version: 2.0.7",
             "App Info"
         )
     End Sub
@@ -170,8 +170,14 @@
 
         Load_Server_List()
 
+        ' save clustered settings
         My.Settings.Is_Clustered = isClustered
         My.Settings.Save()
         My.Settings.Reload()
+    End Sub
+
+    Private Sub PresetsButton_Click(sender As Object, e As EventArgs) Handles PresetsButton.Click
+        Presets.ShowDialog()
+        Presets.Activate()
     End Sub
 End Class

--- a/CS2ServerPicker/CS2ServerPicker.vbproj
+++ b/CS2ServerPicker/CS2ServerPicker.vbproj
@@ -121,6 +121,24 @@
       <DependentUpon>App.vb</DependentUpon>
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Presets\AddPresetForm.Designer.vb">
+      <DependentUpon>AddPresetForm.vb</DependentUpon>
+    </Compile>
+    <Compile Include="Presets\AddPresetForm.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Presets\DeletePresetForm.Designer.vb">
+      <DependentUpon>DeletePresetForm.vb</DependentUpon>
+    </Compile>
+    <Compile Include="Presets\DeletePresetForm.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Presets\Presets.Designer.vb">
+      <DependentUpon>Presets.vb</DependentUpon>
+    </Compile>
+    <Compile Include="Presets\Presets.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Services\DataGridViewService.vb" />
     <Compile Include="Services\PingService.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
@@ -151,6 +169,15 @@
       <LastGenOutput>Resources.Designer.vb</LastGenOutput>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Presets\AddPresetForm.resx">
+      <DependentUpon>AddPresetForm.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Presets\DeletePresetForm.resx">
+      <DependentUpon>DeletePresetForm.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Presets\Presets.resx">
+      <DependentUpon>Presets.vb</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/CS2ServerPicker/My Project/AssemblyInfo.vb
+++ b/CS2ServerPicker/My Project/AssemblyInfo.vb
@@ -32,6 +32,6 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")>
 
-<Assembly: AssemblyVersion("2.0.6.0")>
-<Assembly: AssemblyFileVersion("2.0.6.0")>
+<Assembly: AssemblyVersion("2.0.7.0")>
+<Assembly: AssemblyFileVersion("2.0.7.0")>
 <Assembly: NeutralResourcesLanguage("en")>

--- a/CS2ServerPicker/Presets/AddPresetForm.Designer.vb
+++ b/CS2ServerPicker/Presets/AddPresetForm.Designer.vb
@@ -1,0 +1,102 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class AddPresetForm
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.PresetServersCheckedListBox = New System.Windows.Forms.CheckedListBox()
+        Me.PresetNameLabel = New System.Windows.Forms.Label()
+        Me.AddPresetNameTextBox = New System.Windows.Forms.TextBox()
+        Me.PresetServersLabel = New System.Windows.Forms.Label()
+        Me.AddPresetButton = New System.Windows.Forms.Button()
+        Me.SuspendLayout()
+        '
+        'PresetServersCheckedListBox
+        '
+        Me.PresetServersCheckedListBox.Font = New System.Drawing.Font("Arial Rounded MT Bold", 8.5!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.PresetServersCheckedListBox.FormattingEnabled = True
+        Me.PresetServersCheckedListBox.Location = New System.Drawing.Point(59, 97)
+        Me.PresetServersCheckedListBox.Name = "PresetServersCheckedListBox"
+        Me.PresetServersCheckedListBox.Size = New System.Drawing.Size(271, 310)
+        Me.PresetServersCheckedListBox.TabIndex = 0
+        '
+        'PresetNameLabel
+        '
+        Me.PresetNameLabel.AutoSize = True
+        Me.PresetNameLabel.Location = New System.Drawing.Point(56, 21)
+        Me.PresetNameLabel.Name = "PresetNameLabel"
+        Me.PresetNameLabel.Size = New System.Drawing.Size(95, 16)
+        Me.PresetNameLabel.TabIndex = 1
+        Me.PresetNameLabel.Text = "Preset Name"
+        '
+        'AddPresetNameTextBox
+        '
+        Me.AddPresetNameTextBox.Font = New System.Drawing.Font("Arial Rounded MT Bold", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.AddPresetNameTextBox.Location = New System.Drawing.Point(59, 44)
+        Me.AddPresetNameTextBox.Name = "AddPresetNameTextBox"
+        Me.AddPresetNameTextBox.Size = New System.Drawing.Size(194, 25)
+        Me.AddPresetNameTextBox.TabIndex = 2
+        '
+        'PresetServersLabel
+        '
+        Me.PresetServersLabel.AutoSize = True
+        Me.PresetServersLabel.Location = New System.Drawing.Point(56, 74)
+        Me.PresetServersLabel.Name = "PresetServersLabel"
+        Me.PresetServersLabel.Size = New System.Drawing.Size(109, 16)
+        Me.PresetServersLabel.TabIndex = 3
+        Me.PresetServersLabel.Text = "Preset Servers"
+        '
+        'AddPresetButton
+        '
+        Me.AddPresetButton.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.AddPresetButton.Location = New System.Drawing.Point(130, 423)
+        Me.AddPresetButton.Name = "AddPresetButton"
+        Me.AddPresetButton.Size = New System.Drawing.Size(123, 24)
+        Me.AddPresetButton.TabIndex = 8
+        Me.AddPresetButton.Text = "Add Preset"
+        Me.AddPresetButton.UseVisualStyleBackColor = True
+        '
+        'AddPresetForm
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 15.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(400, 464)
+        Me.Controls.Add(Me.AddPresetButton)
+        Me.Controls.Add(Me.PresetServersLabel)
+        Me.Controls.Add(Me.AddPresetNameTextBox)
+        Me.Controls.Add(Me.PresetNameLabel)
+        Me.Controls.Add(Me.PresetServersCheckedListBox)
+        Me.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
+        Me.MaximizeBox = False
+        Me.Name = "AddPresetForm"
+        Me.Text = "Add Preset"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents PresetServersCheckedListBox As CheckedListBox
+    Friend WithEvents PresetNameLabel As Label
+    Friend WithEvents AddPresetNameTextBox As TextBox
+    Friend WithEvents PresetServersLabel As Label
+    Friend WithEvents AddPresetButton As Button
+End Class

--- a/CS2ServerPicker/Presets/AddPresetForm.resx
+++ b/CS2ServerPicker/Presets/AddPresetForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/CS2ServerPicker/Presets/AddPresetForm.vb
+++ b/CS2ServerPicker/Presets/AddPresetForm.vb
@@ -1,0 +1,67 @@
+﻿Imports Newtonsoft.Json
+Imports Newtonsoft.Json.Linq
+Imports System.IO
+
+Public Class AddPresetForm
+    Private Sub AddPresetForm_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        ' reset checked list box items
+        PresetServersCheckedListBox.Items.Clear()
+
+        ' load server dictionary names to checked list box on add preset form load
+        Dim serverDictionary As Dictionary(Of String, String) = IIf(App.Get_Is_Clustered(), App.Get_Server_Dictionary_Clustered(), App.Get_Server_Dictionary_Unclustered())
+
+        For Each kvp As KeyValuePair(Of String, String) In serverDictionary
+            PresetServersCheckedListBox.Items.Add(kvp.Key)
+        Next
+    End Sub
+
+    Private Sub AddPresetButton_Click(sender As Object, e As EventArgs) Handles AddPresetButton.Click
+        ' add/create a preset from selected servers on add preset button click
+        Dim presetName As String = AddPresetNameTextBox.Text
+        Dim regex As Text.RegularExpressions.Regex = New Text.RegularExpressions.Regex("[^a-zA-Z0-9]")
+
+        If String.IsNullOrWhiteSpace(presetName) Or regex.IsMatch(presetName) Then
+            MessageBox.Show("Preset name field cannot be empty or have special characters.", "Info")
+
+            Return
+        End If
+
+        If PresetServersCheckedListBox.CheckedItems.Count <= 0 Then
+            MessageBox.Show("Please select atleast 1 or more servers to add a preset.", "Info")
+
+            Return
+        End If
+
+        Try
+            Dim jObj As JObject = JObject.Parse(File.ReadAllText("presets.json"))
+
+            If jObj.ContainsKey(presetName.Replace(" ", "")) Then
+                MessageBox.Show("Given preset name already exists.", "Info")
+
+                Return
+            End If
+
+            ' create property using preset name trimmed as key with object as value that contains necessary props 
+            ' "presetName" prop with untrimmed preset name as string value and "servers" prop contains the checked items as JArray value
+            jObj.Add(presetName.Replace(" ", ""), New JObject(
+                     New JProperty("presetName", presetName),
+                     New JProperty("clustered", App.Get_Is_Clustered()),
+                     New JProperty("servers", JArray.FromObject(PresetServersCheckedListBox.CheckedItems))
+                )
+            )
+
+            ' serialize jObj to presets json file
+            File.WriteAllText("presets.json", JsonConvert.SerializeObject(jObj, Formatting.Indented))
+
+            ' refresh/reload presets control data grids
+            Load_Presets()
+        Catch ex As Exception
+            MessageBox.Show("An error has occured while adding preset! Please report to github issue-tracker. Error: " _
+                + Environment.NewLine + Environment.NewLine + ex.Message, "Add Preset Error")
+
+            Return
+        End Try
+
+        MessageBox.Show("Succesfully added preset!")
+    End Sub
+End Class

--- a/CS2ServerPicker/Presets/DeletePresetForm.Designer.vb
+++ b/CS2ServerPicker/Presets/DeletePresetForm.Designer.vb
@@ -1,0 +1,78 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class DeletePresetForm
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.DeletePresetNameTextBox = New System.Windows.Forms.TextBox()
+        Me.PresetNameLabel = New System.Windows.Forms.Label()
+        Me.DeletePresetButton = New System.Windows.Forms.Button()
+        Me.SuspendLayout()
+        '
+        'DeletePresetNameTextBox
+        '
+        Me.DeletePresetNameTextBox.Font = New System.Drawing.Font("Arial Rounded MT Bold", 9.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.DeletePresetNameTextBox.Location = New System.Drawing.Point(50, 47)
+        Me.DeletePresetNameTextBox.Name = "DeletePresetNameTextBox"
+        Me.DeletePresetNameTextBox.Size = New System.Drawing.Size(194, 25)
+        Me.DeletePresetNameTextBox.TabIndex = 4
+        '
+        'PresetNameLabel
+        '
+        Me.PresetNameLabel.AutoSize = True
+        Me.PresetNameLabel.Location = New System.Drawing.Point(47, 26)
+        Me.PresetNameLabel.Name = "PresetNameLabel"
+        Me.PresetNameLabel.Size = New System.Drawing.Size(95, 16)
+        Me.PresetNameLabel.TabIndex = 3
+        Me.PresetNameLabel.Text = "Preset Name"
+        '
+        'DeletePresetButton
+        '
+        Me.DeletePresetButton.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.DeletePresetButton.Location = New System.Drawing.Point(87, 88)
+        Me.DeletePresetButton.Name = "DeletePresetButton"
+        Me.DeletePresetButton.Size = New System.Drawing.Size(123, 24)
+        Me.DeletePresetButton.TabIndex = 9
+        Me.DeletePresetButton.Text = "Delete Preset"
+        Me.DeletePresetButton.UseVisualStyleBackColor = True
+        '
+        'DeletePresetForm
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 15.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(306, 130)
+        Me.Controls.Add(Me.DeletePresetButton)
+        Me.Controls.Add(Me.DeletePresetNameTextBox)
+        Me.Controls.Add(Me.PresetNameLabel)
+        Me.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
+        Me.MaximizeBox = False
+        Me.Name = "DeletePresetForm"
+        Me.Text = "DeletePresetForm"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents DeletePresetNameTextBox As TextBox
+    Friend WithEvents PresetNameLabel As Label
+    Friend WithEvents DeletePresetButton As Button
+End Class

--- a/CS2ServerPicker/Presets/DeletePresetForm.resx
+++ b/CS2ServerPicker/Presets/DeletePresetForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/CS2ServerPicker/Presets/DeletePresetForm.vb
+++ b/CS2ServerPicker/Presets/DeletePresetForm.vb
@@ -1,0 +1,42 @@
+﻿Imports Newtonsoft.Json
+Imports Newtonsoft.Json.Linq
+Imports System.IO
+
+Public Class DeletePresetForm
+    Private Sub DeletePresetButton_Click(sender As Object, e As EventArgs) Handles DeletePresetButton.Click
+        ' delete a preset from given preset name on delete preset button click
+        Dim presetName As String = DeletePresetNameTextBox.Text
+
+        If String.IsNullOrWhiteSpace(presetName) Then
+            MessageBox.Show("Preset name field cannot be empty.", "Info")
+
+            Return
+        End If
+
+        Try
+            Dim jObj As JObject = JObject.Parse(File.ReadAllText("presets.json"))
+
+            If Not jObj.ContainsKey(presetName.Replace(" ", "")) Then
+                MessageBox.Show("Given preset name does not exists.", "Info")
+
+                Return
+            End If
+
+            ' remove property from jObj
+            jObj.Remove(presetName.Replace(" ", ""))
+
+            ' serialize jObj to presets json file
+            File.WriteAllText("presets.json", JsonConvert.SerializeObject(jObj, Formatting.Indented))
+
+            ' refresh/reload presets control data grids
+            Load_Presets()
+        Catch ex As Exception
+            MessageBox.Show("An error has occured while deleting preset! Please report to github issue-tracker. Error: " _
+                + Environment.NewLine + Environment.NewLine + ex.Message, "Delete Preset Error")
+
+            Return
+        End Try
+
+        MessageBox.Show("Succesfully deleted preset!")
+    End Sub
+End Class

--- a/CS2ServerPicker/Presets/Presets.Designer.vb
+++ b/CS2ServerPicker/Presets/Presets.Designer.vb
@@ -1,0 +1,165 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+Partial Class Presets
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Dim DataGridViewCellStyle1 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Dim DataGridViewCellStyle2 As System.Windows.Forms.DataGridViewCellStyle = New System.Windows.Forms.DataGridViewCellStyle()
+        Me.PresetsDataGridView = New System.Windows.Forms.DataGridView()
+        Me.PresetList = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.PresetServerListDataGridView = New System.Windows.Forms.DataGridView()
+        Me.PresetServers = New System.Windows.Forms.DataGridViewTextBoxColumn()
+        Me.BlockPresetServersButton = New System.Windows.Forms.Button()
+        Me.AddPresetFormButton = New System.Windows.Forms.Button()
+        Me.DeletePresetFormButton = New System.Windows.Forms.Button()
+        CType(Me.PresetsDataGridView, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.PresetServerListDataGridView, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.SuspendLayout()
+        '
+        'PresetsDataGridView
+        '
+        Me.PresetsDataGridView.AllowUserToAddRows = False
+        Me.PresetsDataGridView.AllowUserToDeleteRows = False
+        Me.PresetsDataGridView.AllowUserToOrderColumns = True
+        Me.PresetsDataGridView.AllowUserToResizeRows = False
+        Me.PresetsDataGridView.BorderStyle = System.Windows.Forms.BorderStyle.None
+        DataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter
+        DataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle1.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.PresetsDataGridView.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle1
+        Me.PresetsDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        Me.PresetsDataGridView.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.PresetList})
+        Me.PresetsDataGridView.Location = New System.Drawing.Point(30, 52)
+        Me.PresetsDataGridView.Name = "PresetsDataGridView"
+        Me.PresetsDataGridView.RowHeadersVisible = False
+        Me.PresetsDataGridView.RowHeadersWidth = 51
+        Me.PresetsDataGridView.RowTemplate.Height = 24
+        Me.PresetsDataGridView.Size = New System.Drawing.Size(243, 297)
+        Me.PresetsDataGridView.TabIndex = 0
+        '
+        'PresetList
+        '
+        Me.PresetList.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill
+        Me.PresetList.HeaderText = "Presets"
+        Me.PresetList.MinimumWidth = 6
+        Me.PresetList.Name = "PresetList"
+        Me.PresetList.ReadOnly = True
+        Me.PresetList.Resizable = System.Windows.Forms.DataGridViewTriState.[False]
+        '
+        'PresetServerListDataGridView
+        '
+        Me.PresetServerListDataGridView.AllowUserToAddRows = False
+        Me.PresetServerListDataGridView.AllowUserToDeleteRows = False
+        Me.PresetServerListDataGridView.AllowUserToOrderColumns = True
+        Me.PresetServerListDataGridView.AllowUserToResizeRows = False
+        DataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter
+        DataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Control
+        DataGridViewCellStyle2.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        DataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.WindowText
+        DataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight
+        DataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText
+        DataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.[True]
+        Me.PresetServerListDataGridView.ColumnHeadersDefaultCellStyle = DataGridViewCellStyle2
+        Me.PresetServerListDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        Me.PresetServerListDataGridView.Columns.AddRange(New System.Windows.Forms.DataGridViewColumn() {Me.PresetServers})
+        Me.PresetServerListDataGridView.Location = New System.Drawing.Point(299, 52)
+        Me.PresetServerListDataGridView.Name = "PresetServerListDataGridView"
+        Me.PresetServerListDataGridView.ReadOnly = True
+        Me.PresetServerListDataGridView.RowHeadersVisible = False
+        Me.PresetServerListDataGridView.RowHeadersWidth = 51
+        Me.PresetServerListDataGridView.RowTemplate.Height = 24
+        Me.PresetServerListDataGridView.Size = New System.Drawing.Size(458, 362)
+        Me.PresetServerListDataGridView.TabIndex = 1
+        '
+        'PresetServers
+        '
+        Me.PresetServers.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill
+        Me.PresetServers.HeaderText = "Preset Servers"
+        Me.PresetServers.MinimumWidth = 6
+        Me.PresetServers.Name = "PresetServers"
+        Me.PresetServers.ReadOnly = True
+        Me.PresetServers.Resizable = System.Windows.Forms.DataGridViewTriState.[False]
+        '
+        'BlockPresetServersButton
+        '
+        Me.BlockPresetServersButton.BackColor = System.Drawing.Color.FromArgb(CType(CType(255, Byte), Integer), CType(CType(128, Byte), Integer), CType(CType(128, Byte), Integer))
+        Me.BlockPresetServersButton.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.BlockPresetServersButton.Location = New System.Drawing.Point(54, 368)
+        Me.BlockPresetServersButton.Name = "BlockPresetServersButton"
+        Me.BlockPresetServersButton.Size = New System.Drawing.Size(181, 46)
+        Me.BlockPresetServersButton.TabIndex = 4
+        Me.BlockPresetServersButton.Text = "Block By Selected Preset"
+        Me.BlockPresetServersButton.UseVisualStyleBackColor = False
+        '
+        'AddPresetFormButton
+        '
+        Me.AddPresetFormButton.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.AddPresetFormButton.Location = New System.Drawing.Point(533, 22)
+        Me.AddPresetFormButton.Name = "AddPresetFormButton"
+        Me.AddPresetFormButton.Size = New System.Drawing.Size(109, 24)
+        Me.AddPresetFormButton.TabIndex = 8
+        Me.AddPresetFormButton.Text = "Add Preset"
+        Me.AddPresetFormButton.UseVisualStyleBackColor = True
+        '
+        'DeletePresetFormButton
+        '
+        Me.DeletePresetFormButton.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.DeletePresetFormButton.Location = New System.Drawing.Point(648, 22)
+        Me.DeletePresetFormButton.Name = "DeletePresetFormButton"
+        Me.DeletePresetFormButton.Size = New System.Drawing.Size(109, 24)
+        Me.DeletePresetFormButton.TabIndex = 9
+        Me.DeletePresetFormButton.Text = "Delete Preset"
+        Me.DeletePresetFormButton.UseVisualStyleBackColor = True
+        '
+        'Presets
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 15.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(800, 438)
+        Me.Controls.Add(Me.DeletePresetFormButton)
+        Me.Controls.Add(Me.AddPresetFormButton)
+        Me.Controls.Add(Me.BlockPresetServersButton)
+        Me.Controls.Add(Me.PresetServerListDataGridView)
+        Me.Controls.Add(Me.PresetsDataGridView)
+        Me.Font = New System.Drawing.Font("Arial Rounded MT Bold", 7.8!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog
+        Me.MaximizeBox = False
+        Me.Name = "Presets"
+        Me.Text = "Presets"
+        CType(Me.PresetsDataGridView, System.ComponentModel.ISupportInitialize).EndInit()
+        CType(Me.PresetServerListDataGridView, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.ResumeLayout(False)
+
+    End Sub
+
+    Friend WithEvents PresetsDataGridView As DataGridView
+    Friend WithEvents PresetServerListDataGridView As DataGridView
+    Friend WithEvents BlockPresetServersButton As Button
+    Friend WithEvents AddPresetFormButton As Button
+    Friend WithEvents DeletePresetFormButton As Button
+    Friend WithEvents PresetList As DataGridViewTextBoxColumn
+    Friend WithEvents PresetServers As DataGridViewTextBoxColumn
+End Class

--- a/CS2ServerPicker/Presets/Presets.resx
+++ b/CS2ServerPicker/Presets/Presets.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="PresetList.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="PresetServers.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/CS2ServerPicker/Presets/Presets.vb
+++ b/CS2ServerPicker/Presets/Presets.vb
@@ -1,0 +1,35 @@
+﻿Public Class Presets
+    Private Sub AddPresetFormButton_Click(sender As Object, e As EventArgs) Handles AddPresetFormButton.Click
+        AddPresetForm.ShowDialog()
+        AddPresetForm.Activate()
+    End Sub
+
+    Private Sub DeletePresetFormButton_Click(sender As Object, e As EventArgs) Handles DeletePresetFormButton.Click
+        DeletePresetForm.ShowDialog()
+        DeletePresetForm.Activate()
+    End Sub
+
+    Private Sub Presets_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        Load_Presets()
+    End Sub
+
+    Private Sub PresetsDataGridView_CellEnter(sender As Object, e As DataGridViewCellEventArgs) Handles PresetsDataGridView.CellEnter
+        ' load preset servers for the initial focused (first cell is focused on load) or user selected preset name cell 
+        ' this event gets fired twice on initial load, cell value validations needed
+        Dim presetName As String = PresetsDataGridView.Rows(e.RowIndex).Cells(0).Value
+
+        Load_Preset_Servers(presetName)
+    End Sub
+
+    Private Sub BlockPresetServersButton_Click(sender As Object, e As EventArgs) Handles BlockPresetServersButton.Click
+        If PresetServerListDataGridView.Rows.Count <= 0 Then
+            MessageBox.Show("Please select a preset that contain servers.", "Info")
+
+            Return
+        End If
+
+        ActiveForm.Close()
+
+        Block_Preset_Servers()
+    End Sub
+End Class

--- a/CS2ServerPicker/Services/DataGridViewService.vb
+++ b/CS2ServerPicker/Services/DataGridViewService.vb
@@ -1,16 +1,84 @@
-﻿Module DataGridViewService
-    Public Sub Load_Server_List()
-        Dim rowIndex As Integer = 0
+﻿Imports Newtonsoft.Json.Linq
+Imports System.IO
 
+Module DataGridViewService
+    Public Sub Load_Server_List()
         Dim serverDict As Dictionary(Of String, String) = IIf(App.Get_Is_Clustered(), App.Get_Server_Dictionary_Clustered(), App.Get_Server_Dictionary_Unclustered)
 
         ' display each server name key value from server dictionary in the datagridview control
         For Each kvp As KeyValuePair(Of String, String) In serverDict
-            App.Get_DataGridView_Control().Rows().Add()
-            App.Get_DataGridView_Control().Rows(rowIndex).Cells(0).Value = kvp.Key
+            Dim rowIndex As Integer = App.Get_DataGridView_Control().Rows().Add()
 
-            rowIndex += 1
+            App.Get_DataGridView_Control().Rows(rowIndex).Cells(0).Value = kvp.Key
         Next
+    End Sub
+
+    Public Sub Load_Presets()
+        ' load presets into presets data grid view
+
+        ' clear preset and preset servers datagrid view rows
+        Presets.PresetsDataGridView.Rows.Clear()
+        Presets.PresetServerListDataGridView.Rows.Clear()
+
+        Try
+            ' create preset json file if not exists
+            If Not File.Exists("presets.json") Then
+                File.WriteAllText("presets.json", "{}")
+
+                Return
+            End If
+
+            Dim presetsObj As JToken = JObject.Parse(File.ReadAllText("presets.json"))
+
+            ' iterate presetsObj children properties to be added inside presets datagrid view
+            For Each preset As JProperty In presetsObj
+                ' skip adding preset if preset cluster boolean value is not equal to current cluster setting
+                If Not CBool(preset.Value.SelectToken("clustered")) = App.Get_Is_Clustered() Then
+                    Continue For
+                End If
+
+                Dim rowIndex As Integer = Presets.PresetsDataGridView.Rows.Add()
+
+                Presets.PresetsDataGridView.Rows(rowIndex).Cells(0).Value = preset.Value.SelectToken("presetName")
+            Next
+        Catch ex As Exception
+            MessageBox.Show("An error has occured while loading presets! Please report to github issue-tracker. Error: " _
+                + Environment.NewLine + Environment.NewLine + ex.Message, "Load Presets Error")
+        End Try
+    End Sub
+
+    Public Sub Load_Preset_Servers(presetName As String)
+        If String.IsNullOrWhiteSpace(presetName) Then
+            Return
+        End If
+
+        ' clear preset servers datagrid view rows
+        Presets.PresetServerListDataGridView.Rows.Clear()
+
+        Try
+            ' create preset json file if not exists, then refresh/reload preset names inside preset names datagrid view
+            ' this will only get triggered probably if presets.json file was deleted before loading preset servers
+            If Not File.Exists("presets.json") Then
+                MessageBox.Show("Presets missing!. Presets file must have been deleted.", "Info")
+
+                Load_Presets()
+
+                Return
+            End If
+
+            Dim presetsObj As JObject = JObject.Parse(File.ReadAllText("presets.json"))
+
+            ' iterate selected preset name JArray servers to be added inside preset servers datagrid view
+            ' escape preset name prop key to prevent invalid json path exception even if adding preset with special characters is not allowed
+            For Each server As JValue In presetsObj.SelectToken("['" + presetName.Replace(" ", "") + "']" + "." + "servers")
+                Dim rowIndex As Integer = Presets.PresetServerListDataGridView.Rows.Add()
+
+                Presets.PresetServerListDataGridView.Rows(rowIndex).Cells(0).Value = server
+            Next
+        Catch ex As Exception
+            MessageBox.Show("An error has occured while loading preset servers! Please report to github issue-tracker. Error: " _
+               + Environment.NewLine + Environment.NewLine + ex.Message, "Load Preset Servers Error")
+        End Try
     End Sub
 
     Public Sub Clear_Column_Values()

--- a/CS2ServerPicker/Services/PingService.vb
+++ b/CS2ServerPicker/Services/PingService.vb
@@ -59,7 +59,7 @@
 
         row.Cells(1).Value = "Getting latency..."
 
-        ' this loop maintains its context through suspension points (Await) so I don't have to worry about unpredictability
+        ' this loop maintains its context through suspension points (Await) so I don't have to worry about race conditions
         For Each address As String In addresses.Split(",")
             Try
                 Dim result = Await ping.SendPingAsync(address)
@@ -89,7 +89,7 @@
     Public Sub Cancel_Pending_Ping(Optional serverName As String = "")
         Dim pingObjs = App.Get_Ping_Objects_Dictionary()
 
-        If pingObjs.Count < 0 Then
+        If pingObjs.Count <= 0 Then
             Return
         End If
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A lightweight server picker for CS2. Previously developed for CS:GO but is now f
 ### [Releases](https://github.com/FN-FAL113/csgo-server-picker/releases)
 
 ## 📷 Screenshot
-![Screenshot 2023-10-25 095439](https://github.com/FN-FAL113/cs2-server-picker/assets/88238718/74de5ee8-ef02-4bc7-b873-a1b0fc66c0a0)
+![CS2ServerPicker](https://github.com/FN-FAL113/cs2-server-picker/assets/88238718/3e574931-f3f1-4b41-afdc-7dd33a6f87f8)
+![Demo.gif](https://github.com/FN-FAL113/cs2-server-picker/assets/88238718/a46e515c-d591-49e2-ac98-f6f0088bf8eb)
 
 ## ⚙️ Requirements
 - Windows 10 or Above


### PR DESCRIPTION
## Changes
- implemented a suggestion from @kulture (donor) to add presets where users can create presets based on selected servers and blocking can be done by preset. Presets are saved locally inside ```presets.json``` and is advised not to edit the file manually to prevent issues.
- code chores

## To Do
- [x] load servers into add preset form checked list box control
- [x] add preset functionality with proper validations
- [x] delete preset functionality with proper validations
- [x] load preset names into presets datagrid view control
- [x] load selected preset name servers into preset servers datagrid view control
- [x] block by selected preset